### PR TITLE
Added support for REQUIRED_LIST of labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A GitHub Action that blocks PRs that are tagged by WIP (et al) or have WIP in th
 
 Scans labels and title of the PR and fails if it encounters any of the blocked words in them.
 
+Extended to also block a PR if the REQUIRED_LIST is provided and the PR does not have a label that matches any of the values (note that only labels are checked and not the title)
+
 ## Usage
 
 If this solves your problems adding it to your project is straightforward 
@@ -26,6 +28,7 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BLOCK_LIST: "WIP|do not merge|backend not live"
+          REQUIRED_LIST: "release"
 ```
 
 Depending on your project's requrirements you may add / remove triggers and/or branches [Pull request events](https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-event-pull_request)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,4 +50,14 @@ checkForBlockingWords(){
     fi
 }
 
-checkForBlockingWords "$title" "$labels"
+#Block if required words are NOT found in labels
+checkForRequiredWords(){
+    if  echo "${1}" | grep -iE "$REQUIRED_LIST"
+    then
+       return 0
+    else
+       return 1
+    fi
+}
+
+checkForBlockingWords "$title" "$labels" && checkForRequiredWords "$labels"


### PR DESCRIPTION
As a follow-up to the incident on Friday (also based on a suggestion from Gil earlier last week), I'd like to switch the Github PR/merge workflow such that only PRs tagged with a "release" label will be eligible for merging  (this will prevent cases where the PR owner wasn't familiar with the DO_NOT_MERGE label, or when Github automatically updates the target branch as was the case for PR 3035).

However the current WIP Blocker Github Action doesn't support this logic, so I've forked it and extended it to support an additional REQUIRED_LIST param that will do this (basically fail / block the build if a label like "release" is absent)